### PR TITLE
Register custom elements before loading them for the builder

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -16,7 +16,7 @@ namespace BreakdanceCustomElements;
 
 use function Breakdance\Util\getDirectoryPathRelativeToPluginFolder;
 
-add_action('breakdance_loaded', function() {
+add_action('breakdance_loaded', function () {
     \Breakdance\ElementStudio\registerSaveLocation(
         getDirectoryPathRelativeToPluginFolder(__DIR__) . '/elements',
         'BreakdanceCustomElements',
@@ -40,4 +40,7 @@ add_action('breakdance_loaded', function() {
         'Custom Presets',
         false,
     );
-});
+},
+    // register elements before loading them
+    9
+);


### PR DESCRIPTION
Showcase and explanation: https://www.loom.com/share/c49c49f6ff4241b1a1907d3aa115d660

- The elements were being loaded before custom elements were registered